### PR TITLE
Fix: use `name=` instead of `dataset_name=` in prepare_dataset calls

### DIFF
--- a/src/evaluation/pre_no_search.py
+++ b/src/evaluation/pre_no_search.py
@@ -8,13 +8,13 @@ from typing import Any
 import torch
 from accelerate import Accelerator
 from dotenv import load_dotenv
-from models.evaluater import evaluate
 from rich.traceback import install
 from torch.utils.data import DataLoader
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from data.prepare_dataset import prepare_dataset
 from data.prompt import LLM_EVAL_PROMPT
+from models.evaluater import evaluate
 from utils.utils import (
     load_config,
     optimize_model_memory,
@@ -46,7 +46,7 @@ def main() -> None:
 
     _, eval_dataset = prepare_dataset(
         split="train",
-        dataset_name=config.dataset.name,
+        name=config.dataset.name,
         eval_size=config.dataset.num_eval,
     )
     if len(eval_dataset) == 0:

--- a/src/evaluation/pre_search.py
+++ b/src/evaluation/pre_search.py
@@ -47,7 +47,7 @@ def main() -> None:
 
     _, eval_dataset = prepare_dataset(
         split="train",
-        dataset_name=config.dataset.name,
+        name=config.dataset.name,
         eval_size=config.dataset.num_eval,
     )
     if len(eval_dataset) == 0:


### PR DESCRIPTION
**What**  
This PR updates the parameter name when calling `prepare_dataset` in both `pre_no_search.py` and `pre_search.py`, changing `dataset_name=config.dataset.name` to `name=config.dataset.name` to match the function signature.

**Why**  
Passing the wrong keyword (`dataset_name`) caused the dataset loader to ignore the name and fall back to default, breaking evaluation.

**Closes**  
Closes #1