### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ If you use this work in your research, please cite:
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=jiangxinke/Agentic-RAG-R1&type=Date)](https://star-history.com/#jiangxinke/Agentic-RAG-R1&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=jiangxinke/Agentic-RAG-R1&type=Date)](https://star-history.dera.page/#jiangxinke/Agentic-RAG-R1&Date)
 
 ## License 📄
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders. This change points it to a working star history service so the chart displays correctly again.

No other portions of the README are affected.